### PR TITLE
Add method for updating a goal's slug

### DIFF
--- a/lib/Beeminder/Api/Goal.php
+++ b/lib/Beeminder/Api/Goal.php
@@ -94,7 +94,7 @@ class Beeminder_Api_Goal extends Beeminder_Api
     /**
      * Update a goal object
      *
-     * Note: if you need to change the slug you have to call editGoal.
+     * Note: if you need to change the slug you should call updateSlug.
      *
      * @param stdClass altered goal object to update.
      * @return array Array of goals objects.
@@ -110,7 +110,16 @@ class Beeminder_Api_Goal extends Beeminder_Api
             }
         }
 
-        return $this->editGoal( $goal->slug, $parameters ); 
+        return $this->editGoal( $goal->slug, $parameters );
+    }
+
+    /*
+     * Update the slug of a goal.
+     */
+    public function updateSlug( stdClass $goal, $new_slug )
+    {
+        $parameters = array( 'slug' => $new_slug );
+        return $this->editGoal( $goal->slug, $parameters );
     }
 
     public function editGoal($goal, array $options)

--- a/test/Beeminder/Tests/Api/GoalTest.php
+++ b/test/Beeminder/Tests/Api/GoalTest.php
@@ -121,5 +121,23 @@ class Beeminder_Tests_Api_GoalTest extends Beeminder_Tests_ApiTestCase
         $api->createGoal( $parameters );
     }
 
+    public function testUpdateGoalSlug()
+    {
+        $api = $this->getApiMockObject();
+
+        # Should we validate slugs?
+        $goal     = 'original_slug';
+        $new_slug = 'some_new_slug';
+
+        $parameters = array( 'slug' => $new_slug );
+        $expected_options = $parameters;
+
+        $api->expects($this->once())
+            ->method('put')
+            ->with(sprintf('users/:username/goals/%s',$goal), $expected_options );
+
+        $api->updateGoalSlug( $goal, $new_slug );
+    }
+
 
 }

--- a/test/Beeminder/Tests/Api/GoalTest.php
+++ b/test/Beeminder/Tests/Api/GoalTest.php
@@ -121,22 +121,22 @@ class Beeminder_Tests_Api_GoalTest extends Beeminder_Tests_ApiTestCase
         $api->createGoal( $parameters );
     }
 
-    public function testUpdateGoalSlug()
+    public function testUpdateSlug()
     {
         $api = $this->getApiMockObject();
 
         # Should we validate slugs?
-        $goal     = 'original_slug';
-        $new_slug = 'some_new_slug';
+        $goal = (object) array( 'slug' => 'original_slug');
+        $new_slug = (string) 'some_new_slug';
 
         $parameters = array( 'slug' => $new_slug );
         $expected_options = $parameters;
 
         $api->expects($this->once())
             ->method('put')
-            ->with(sprintf('users/:username/goals/%s',$goal), $expected_options );
+            ->with(sprintf('users/:username/goals/%s',$goal->slug), $expected_options );
 
-        $api->updateGoalSlug( $goal, $new_slug );
+        $api->updateSlug( $goal, $new_slug );
     }
 
 


### PR DESCRIPTION
If you want to change a slug the usual 'updateGoal' method will not work as the goal's slug is a part of the goaldata object so when you change it it cannot find the goal to update.

'updateSlug' takes care of this by taking the new slug as a parameter.
