### PR TITLE
Fixes getGoal, adds getGoalWithDatapoints

### DIFF
--- a/lib/Beeminder/Api/Goal.php
+++ b/lib/Beeminder/Api/Goal.php
@@ -46,15 +46,33 @@ class Beeminder_Api_Goal extends Beeminder_Api
      * Fetch information about a single goal.
      * 
      * @param string $slug Goal slug to retrieve.
-     * @return stdClass Object containing 
+     * @param boolan $includeDatapoints whether to include the goal's datapoints
+     * @return stdClass Object containing the goal data.
      */
     public function getGoal($slug, $includeDatapoints = false)
     {
-        return (object)$this->get("users/:username/goals/{$slug}", array(
-            'datapoints' => $includeDatapoints
-        ));
+        $params = array();
+
+        if($includeDatapoints) {
+            # 20150805 - Beeminder API currently requires a
+            # literal string rather than boolean.
+            $params['datapoints'] = 'true';
+        }
+
+        return (object)$this->get("users/:username/goals/{$slug}", $params );
     }
-    
+
+    /**
+     * Fetch goal data including datapoints.
+     *
+     * @param string $slug Goal slug to retrieve.
+     * @return stdClass Object containing the goal data with datapoints included.
+     *
+     */
+    public function getGoalWithDatapoints($slug)
+    {
+        return $this->getGoal($slug, true);
+    }
     
     // ----------------------------------------------------------------------
     // -- Creating Goals

--- a/test/Beeminder/Tests/Api/GoalTest.php
+++ b/test/Beeminder/Tests/Api/GoalTest.php
@@ -11,9 +11,20 @@ class Beeminder_Tests_Api_GoalTest extends Beeminder_Tests_ApiTestCase
 
         $api->expects($this->once())
             ->method('get')
-            ->with('users/:username/goals/goal-1');
+            ->with('users/:username/goals/goal-1', array());
 
         $api->getGoal("goal-1");
+    }
+
+    public function testGetGoalWithDatapoints()
+    {
+        $api = $this->getApiMockObject();
+
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users/:username/goals/goal-1', array('datapoints'=>'true'));
+
+        $api->getGoalWithDatapoints("goal-1");
     }
 
     public function testGetGoals()


### PR DESCRIPTION
This commit does two things:
1. Fixes getGoal($slug, true) by working around a Beeminder API bug.
   It will now fetch the goal including its datapoints. Previously the
   method would always return goals without datapoints.
2. Adds getGoalWithDatapoints($slug)
   Which is a helper method which does the same as getGoal($slug, true)
