### PR TITLE
Advanced datapoint creation

### DIFF
--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -79,17 +79,17 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
     // -- Editing Datapoints
     // ----------------------------------------------------------------------
 
-    public function editDatapoint($datapointId, $goal, $timestamp = null, $value = null, $comment = null)
+    public function editDatapoint($datapointId, $slug, $timestamp = null, $value = null, $comment = null)
     {
         $parameters = array();
         if ($timestamp) $parameters['timestamp'] = $timestamp;
         if ($value)     $parameters['value'] = $value;
         if ($comment)   $parameters['comment'] = $comment;
 
-        return (object)$this->put("users/:username/goals/{$goal}/datapoints/{$datapointId}", $parameters);
+        return (object)$this->put("users/:username/goals/{$slug}/datapoints/{$datapointId}", $parameters);
     }
 
-    public function updateDatapoint($goalName, $datapoint)
+    public function updateDatapoint($slug, $datapoint)
     {
         $parameters = array(
             'timestamp' => $datapoint->timestamp,
@@ -97,7 +97,7 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
             'comment'   => $datapoint->comment
         );
 
-        return (object)$this->put("users/:username/goals/{$goalName}/datapoints/{$datapoint->id}", $parameters);
+        return (object)$this->put("users/:username/goals/{$slug}/datapoints/{$datapoint->id}", $parameters);
     }
 
 
@@ -108,14 +108,14 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
     /**
      * Delete a datapoint.
      *
-     * @param string $goal Slug of the goal to delete from.
+     * @param string $slug Slug of the goal to delete from.
      * @param string $datapointId ID of the datapoint to delete.
      *
      * @return stdClass The deleted datapoint object.
      */
-    public function deleteDatapoint($goal, $datapointId)
+    public function deleteDatapoint($slug, $datapointId)
     {
-        return (object)$this->delete("users/:username/goals/{$goal}/datapoints/{$datapointId}");
+        return (object)$this->delete("users/:username/goals/{$slug}/datapoints/{$datapointId}");
     }
 
 }

--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -55,6 +55,15 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
         return $this->createDatapointAdvanced( $slug, $parameters );
     }
 
+    /**
+     * Create a single datapoint.
+     *
+     * @param string $slug The goal slug to retrieve.
+     * @param array $parameters An Array of parameters to pass to Beeminder.
+     *          You should check the Beeminder API documentation to make sure 
+     *          you are sending valid parameters.
+     * @return object The created datapoint.
+     */
     public function createDatapointAdvanced($slug, $parameters )
     {
         // Send request

--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -39,19 +39,21 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
     // -- Creating Datapoints
     // ----------------------------------------------------------------------
 
-    public function createDatapoint($goal, $value, $comment = '', $timestamp = null, $sendmail = false)
+
+
+    # 20151210 1009 Old signature
+#    public function createDatapoint($goal, $value, $comment = '', $timestamp = null, $sendmail = false )
+    public function createDatapoint($slug, $value, $comment = '')
     {
 
         // Create parameters
         $parameters = array(
-            'timestamp' => ($timestamp == null) ? time() : $timestamp,
-            'value'     => (int)$value,
+            'value'     => $value,
             'comment'   => $comment,
-            'sendmail'  => $sendmail
         );
 
         // Send request
-        return (object)$this->post("users/:username/goals/{$goal}/datapoints", $parameters);
+        return (object)$this->post("users/:username/goals/{$slug}/datapoints", $parameters);
 
     }
 

--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -60,7 +60,7 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
     /**
      * Add multiple data points.
      */
-    public function createDatapoints($goal, $datapoints, $sendmail = false)
+    public function createDatapoints($slug, $datapoints, $sendmail = false)
     {
 
         // Create parameters
@@ -70,7 +70,7 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
         );
 
         // Send request
-        return self::_objectify($this->post("users/:username/goals/{$goal}/datapoints/create_all", $parameters));
+        return self::_objectify($this->post("users/:username/goals/{$slug}/datapoints/create_all", $parameters));
 
     }
 

--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -45,7 +45,6 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
 #    public function createDatapoint($goal, $value, $comment = '', $timestamp = null, $sendmail = false )
     public function createDatapoint($slug, $value, $comment = '')
     {
-
         // Create parameters
         $parameters = array(
             'value'     => $value,
@@ -53,9 +52,15 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
         );
 
         // Send request
-        return (object)$this->post("users/:username/goals/{$slug}/datapoints", $parameters);
-
+        return $this->createDatapointAdvanced( $slug, $parameters );
     }
+
+    public function createDatapointAdvanced($slug, $parameters )
+    {
+        // Send request
+        return (object)$this->post("users/:username/goals/{$slug}/datapoints", $parameters);
+    }
+
 
     /**
      * Add multiple data points.

--- a/lib/Beeminder/Api/Datapoint.php
+++ b/lib/Beeminder/Api/Datapoint.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Beeminder_Api_Datapoint
- * 
+ *
  * API helper for working with Datapoint resources. Use these when tracking any
  * kind of data.
- * 
+ *
  * @package    BeeminderApi
  * @subpackage API
  * @author     Phil Newton <phil@sodaware.net>
@@ -13,15 +13,15 @@
 
 
 class Beeminder_Api_Datapoint extends Beeminder_Api
-{   
-    
+{
+
     // ----------------------------------------------------------------------
     // -- Fetching Information
     // ----------------------------------------------------------------------
-    
+
     /**
      * Fetch all datapoints for a single goal.
-     * 
+     *
      * @param string $slug The goal slug to retrieve.
      * @return array Array of datapoint objects.
      */
@@ -29,19 +29,19 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
     {
         // Fetch datapoints
         $datapoints = $this->get("users/:username/goals/{$slug}/datapoints");
-        
+
         // Convert to array of objects (if present)
         return self::_objectify($datapoints);
     }
-    
-    
+
+
     // ----------------------------------------------------------------------
     // -- Creating Datapoints
     // ----------------------------------------------------------------------
-    
+
     public function createDatapoint($goal, $value, $comment = '', $timestamp = null, $sendmail = false)
     {
-        
+
         // Create parameters
         $parameters = array(
             'timestamp' => ($timestamp == null) ? time() : $timestamp,
@@ -49,10 +49,10 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
             'comment'   => $comment,
             'sendmail'  => $sendmail
         );
-        
+
         // Send request
         return (object)$this->post("users/:username/goals/{$goal}/datapoints", $parameters);
-        
+
     }
 
     /**
@@ -60,19 +60,19 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
      */
     public function createDatapoints($goal, $datapoints, $sendmail = false)
     {
-        
+
         // Create parameters
         $parameters = array(
             'datapoints'=> $datapoints,
             'sendmail'  => $sendmail
         );
-        
+
         // Send request
         return self::_objectify($this->post("users/:username/goals/{$goal}/datapoints/create_all", $parameters));
-        
+
     }
-    
-    
+
+
     // ----------------------------------------------------------------------
     // -- Editing Datapoints
     // ----------------------------------------------------------------------
@@ -83,7 +83,7 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
         if ($timestamp) $parameters['timestamp'] = $timestamp;
         if ($value)     $parameters['value'] = $value;
         if ($comment)   $parameters['comment'] = $comment;
-        
+
         return (object)$this->put("users/:username/goals/{$goal}/datapoints/{$datapointId}", $parameters);
     }
 
@@ -94,26 +94,26 @@ class Beeminder_Api_Datapoint extends Beeminder_Api
             'value'     => $datapoint->value,
             'comment'   => $datapoint->comment
         );
-        
+
         return (object)$this->put("users/:username/goals/{$goalName}/datapoints/{$datapoint->id}", $parameters);
     }
-    
-    
+
+
     // ----------------------------------------------------------------------
     // -- Deleting Datapoints
     // ----------------------------------------------------------------------
-    
+
     /**
      * Delete a datapoint.
-     * 
+     *
      * @param string $goal Slug of the goal to delete from.
      * @param string $datapointId ID of the datapoint to delete.
-     * 
+     *
      * @return stdClass The deleted datapoint object.
      */
     public function deleteDatapoint($goal, $datapointId)
     {
         return (object)$this->delete("users/:username/goals/{$goal}/datapoints/{$datapointId}");
     }
-    
+
 }

--- a/lib/Beeminder/Api/Goal.php
+++ b/lib/Beeminder/Api/Goal.php
@@ -140,9 +140,9 @@ class Beeminder_Api_Goal extends Beeminder_Api
         return $this->editGoal( $goal->slug, $parameters );
     }
 
-    public function editGoal($goal, array $options)
+    public function editGoal($slug, array $options)
     {
-        return (object)$this->put("users/:username/goals/{$goal}", $options);
+        return (object)$this->put("users/:username/goals/{$slug}", $options);
     }
 
     // ----------------------------------------------------------------------

--- a/test/Beeminder/Tests/Api/DatapointTest.php
+++ b/test/Beeminder/Tests/Api/DatapointTest.php
@@ -75,7 +75,7 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
         $newPoint = $api->createDatapoint('goal-1', 123.456 );
     }
 
-    public function testCreateDatapointWithoutDetails()
+    public function testCreateDatapointDefaultComment()
     {
         $api = $this->getApiMockObject();
 

--- a/test/Beeminder/Tests/Api/DatapointTest.php
+++ b/test/Beeminder/Tests/Api/DatapointTest.php
@@ -47,17 +47,15 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
         $api = $this->getApiMockObject();
 
         $parameters = array(
-            'timestamp' => 1,
             'value'     => 123,
             'comment'   => 'Test Datapoint 1',
-            'sendmail'  => false,
         );
 
         $api->expects($this->once())
             ->method('post')
             ->with('users/:username/goals/goal-1/datapoints', $parameters);
 
-        $newPoint = $api->createDatapoint('goal-1', 123, 'Test Datapoint 1', 1, false);
+        $newPoint = $api->createDatapoint('goal-1', 123, 'Test Datapoint 1');
     }
 
 
@@ -65,18 +63,16 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
     {
         $api = $this->getApiMockObject();
 
-        $parameters = array(
-            'timestamp' => 1,
-            'value'     => 123.456,
-            'comment'   => 'Test Datapoint 1',
-            'sendmail'  => false,
+        $expected = array(
+            'value'   => 123.456,
+            'comment' => '',
         );
 
         $api->expects($this->once())
             ->method('post')
-            ->with('users/:username/goals/goal-1/datapoints', $parameters);
+            ->with('users/:username/goals/goal-1/datapoints', $expected);
 
-        $newPoint = $api->createDatapoint('goal-1', 123.456, 'Test Datapoint 1', 1, false);
+        $newPoint = $api->createDatapoint('goal-1', 123.456 );
     }
 
     public function testCreateDatapointWithoutDetails()
@@ -85,9 +81,7 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
 
         $parameters = array(
             'value'     => 123,
-            'timestamp' => time(),
             'comment'   => '',
-            'sendmail'  => false
         );
 
         $api->expects($this->once())

--- a/test/Beeminder/Tests/Api/DatapointTest.php
+++ b/test/Beeminder/Tests/Api/DatapointTest.php
@@ -91,6 +91,29 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
         $newPoint = $api->createDatapoint('goal-1', 123);
     }
 
+    public function testCreateDatapointAdvanced()
+    {
+        $api = $this->getApiMockObject();
+
+        $slug = 'goal-1';
+
+        $parameters = array(
+            'value'                 => 123,
+            'comment'               => '',
+            'timestamp'             => 123456789,
+            'requestid'             => 'unique',
+            'daystamp'              => '20151210',
+            'not_used_by_beeminder' => 'but we will send it anyway',
+        );
+
+        $api->expects($this->once())
+            ->method('post')
+            ->with('users/:username/goals/goal-1/datapoints', $parameters);
+
+        $newPoint = $api->createDatapointAdvanced( $slug, $parameters );
+    }
+
+
 
     public function testCreateDatapoints()
     {

--- a/test/Beeminder/Tests/Api/DatapointTest.php
+++ b/test/Beeminder/Tests/Api/DatapointTest.php
@@ -55,12 +55,28 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
 
         $api->expects($this->once())
             ->method('post')
-            ->with('users/:username/goals/goal-1/datapoints', $parameters)
-            ->will($this->returnValue($this->_getTestDatapoint()));
+            ->with('users/:username/goals/goal-1/datapoints', $parameters);
 
         $newPoint = $api->createDatapoint('goal-1', 123, 'Test Datapoint 1', 1, false);
+    }
 
-        $this->assertEquals($this->_getTestDatapoint(), $newPoint, "->createDatapoint() returns created item");
+
+    public function testCreateDatapointFloatingPoint()
+    {
+        $api = $this->getApiMockObject();
+
+        $parameters = array(
+            'timestamp' => 1,
+            'value'     => 123.456,
+            'comment'   => 'Test Datapoint 1',
+            'sendmail'  => false,
+        );
+
+        $api->expects($this->once())
+            ->method('post')
+            ->with('users/:username/goals/goal-1/datapoints', $parameters);
+
+        $newPoint = $api->createDatapoint('goal-1', 123.456, 'Test Datapoint 1', 1, false);
     }
 
     public function testCreateDatapointWithoutDetails()
@@ -74,20 +90,13 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
             'sendmail'  => false
         );
 
-        $expectedResult = $this->_getTestDatapoint();
-        $expectedResult->timestamp = $parameters['timestamp'];
-        $expectedResult->comment   = '';
-        $expectedResult->update_at = $parameters['timestamp'];
-
         $api->expects($this->once())
             ->method('post')
-            ->with('users/:username/goals/goal-1/datapoints', $parameters)
-            ->will($this->returnValue($expectedResult));
+            ->with('users/:username/goals/goal-1/datapoints', $parameters);
 
         $newPoint = $api->createDatapoint('goal-1', 123);
-
-        $this->assertEquals($expectedResult, $newPoint, "->createDatapoint() returns created item");
     }
+
 
     public function testCreateDatapoints()
     {
@@ -104,8 +113,7 @@ class Beeminder_Tests_Api_DatapointTest extends Beeminder_Tests_ApiTestCase
 
         $api->expects($this->once())
             ->method('post')
-            ->with('users/:username/goals/goal-1/datapoints/create_all', $parameters)
-            ->will($this->returnValue($this->_getTestDatapoint()));
+            ->with('users/:username/goals/goal-1/datapoints/create_all', $parameters);
 
         $api->createDatapoints('goal-1', $parameters['datapoints'], $parameters['sendmail']);
     }


### PR DESCRIPTION
Simplify the parameters accepted by createDatapoint()
Allow the passing of arbitrary parameters when creating a datapoint by using createDatapointAdvanced()

Note: This changes the signature of createDatapoint() so is possibly a breaking change, but it is only the optional arguments that have been removed, anyone who was relying on them will need to update to use createDatapointAdvanced() instead.
